### PR TITLE
Feat/device token dispatch group

### DIFF
--- a/push/pubspec.yaml
+++ b/push/pubspec.yaml
@@ -1,6 +1,6 @@
 name: push
 description: Push notifications in Flutter without firebase_messaging.
-version: 0.0.4
+version: 0.0.5
 repository: https://github.com/ben-xD/push
 issue_tracker: https://github.com/ben-xD/push/issues?q=is%3Aissue+is%3Aopen
 homepage: https://orth.uk/


### PR DESCRIPTION
## Issue

It appears that if you use multiple packages that hook into push notifications, some might trigger `didRegisterForRemoteNotificationsWithDeviceToken` multiple times (in my case, twice).

Because you can only leave a `DispatchGroup` as many times as you enter it, `deviceTokenReadyDispatchGroup.leave()` throws an error. This crashes the app.

## Solution
Track how many times the `DispatchGroup` was entered, so extra leaves are ignored.